### PR TITLE
Add missing parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project was initially inspired by [zer0b.in](https://github.com/zer0bin-dev
 | `/pastes/{paste_id}` | `GET` | Get information about a paste | None
 | `/api/pastes/{paste_id}/raw` | `GET` | Get the raw paste | None
 | `/api/stats` | `GET` | Does nothing | None
-| `/pastes` | `POST` | Create a paste | `language` `content`
+| `/pastes` | `POST` | Create a paste | `language`, `content`, `expiration`
 
 ## Installation
 


### PR DESCRIPTION
Adds the `expiration` parameter to the API docs